### PR TITLE
fix missing reference labels in rendered docs (update CSS)

### DIFF
--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -71,3 +71,8 @@
 /* Table with a scrollbar */
 .bodycontainer { max-height: 600px; width: 100%; margin: 0; overflow-y: auto; }
 .table-scrollable { margin: 0; padding: 0; }
+
+.label {
+    color: #222222;
+    font-size: 100%;
+}


### PR DESCRIPTION
This PR is to update [pysal-styles.css](https://github.com/pysal/submodule_template/blob/master/doc/_static/pysal-styles.css) so that the reference labels will be properly rendered. 

Before, the reference labels look like they were missing:
![2018-11-03-0949-1541263785-sel](https://user-images.githubusercontent.com/118042/47954938-ee66f200-df4d-11e8-94c8-3780b83f472b.png)

The Reference page now looks like the following:
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/7359284/50413460-307d1900-07c4-11e9-9710-c94a4424904f.png">

It is suggested that all the pysal submodules update their pysal-styles.css file so that the reference labels can be properly rendered. 