### PR TITLE
WIP BUG: missing MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt CHANGELOG.txt MANIFEST.in requirements_docs.txt requirements_tests.txt requirements.txt
+


### PR DESCRIPTION
Without `MANIFEST.in`, `requirements.txt` is not included in [sdists](https://docs.python.org/2/distutils/sourcedist.html), and  installation of the package [will fail](https://ci.appveyor.com/project/conda-forge/staged-recipes/builds/24466537#L731).  