### PR TITLE
readthedocs from v1 to v2

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,28 @@
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
 python:
-    version: 3.5
-    setup_py_install: true
-    pip_install: true
-    extra_requirements:
-        - tests
-        - docs
+    version: 3.7
+    # use pip to install all dependencies (will not work for rtree)
+    install:
+        - requirements: requirements.txt
+        - method: pip
+          path: .
+          extra_requirements:
+              - tests
+              - docs
+
+# If your package has dependencies which cannot be properly installed using pip
+# (e.g. rtree), you should create an environment.yml file and configure as
+# follows (see spaghetti example
+# https://github.com/pysal/spaghetti/blob/master/readthedocs.yml):
+# comment these two lines if all the dependencies can be installed using pip
+conda:
+  environment: environment.yml


### PR DESCRIPTION
`pip install` dependencies is recommended as `conda install` requires more memory which could incur issues on readthedocs building. 
