### PR TITLE
(docs) css style

### DIFF
--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -72,10 +72,10 @@
 .bodycontainer { max-height: 600px; width: 100%; margin: 0; overflow-y: auto; }
 .table-scrollable { margin: 0; padding: 0; }
 
-/*.label {*/
-/*    color: #222222;*/
-/*    font-size: 100%;*/
-/*}*/
+.label {
+    color: #ff0000;
+    /*font-size: 100%;*/
+}
 
 div.body {
     max-width: 1080px;

--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -72,7 +72,11 @@
 .bodycontainer { max-height: 600px; width: 100%; margin: 0; overflow-y: auto; }
 .table-scrollable { margin: 0; padding: 0; }
 
-.label {
-    color: #222222;
-    font-size: 100%;
+/*.label {*/
+/*    color: #222222;*/
+/*    font-size: 100%;*/
+/*}*/
+
+div.body {
+    max-width: 1080px;
 }


### PR DESCRIPTION
change the css to accommodate new versions of sphinx and sphinx bootstrap theme
https://github.com/pysal/giddy/pull/97 https://github.com/pysal/giddy/pull/102
The References page will look like this:
![image](https://user-images.githubusercontent.com/7359284/60284411-5349d080-98c0-11e9-93cc-156c4bc22f8d.png)
