### PR TITLE
(docs) automatically document class members + intersphinx example

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -253,7 +253,8 @@ numpydoc_use_plots = True
 
 # automatically document class members
 autodoc_default_options = {
-    'members': True
+    'members': True,
+    'undoc-members': True
 }
 
 # display the source code for Plot directive
@@ -262,6 +263,12 @@ plot_include_source = True
 def setup(app):
     app.add_stylesheet("pysal-styles.css")
 
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3.6/': None}
+# Configuration for intersphinx: add your dependent packages' doc urls.
+intersphinx_mapping = {"python": ('https://docs.python.org/3', None),
+                       'numpy': ('https://docs.scipy.org/doc/numpy', None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+                       'libpysal': ('https://pysal.org/libpysal/', None),
+                       'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+                       'matplotlib':("https://matplotlib.org/", None)
+                       }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -246,10 +246,15 @@ texinfo_documents = [
 
 # Generate the API documentation when building
 autosummary_generate = True
-numpydoc_show_class_members = True
-class_members_toctree = True
-numpydoc_show_inherited_class_members = True
+
+# avoid showing members twice
+numpydoc_show_class_members = False
 numpydoc_use_plots = True
+
+# automatically document class members
+autodoc_default_options = {
+    'members': True
+}
 
 # display the source code for Plot directive
 plot_include_source = True

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -246,11 +246,15 @@ texinfo_documents = [
 
 # Generate the API documentation when building
 autosummary_generate = True
-numpydoc_show_class_members = True
-class_members_toctree = True
-numpydoc_show_inherited_class_members = True
+
+# avoid showing members twice
+numpydoc_show_class_members = False
 numpydoc_use_plots = True
 
+# automatically document class members
+autodoc_default_options = {
+    'members': True
+}
 # display the source code for Plot directive
 plot_include_source = True
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,4 @@
 sphinx>=1.4.3
 sphinxcontrib-bibtex
-sphinx_bootstrap_theme
+sphinx_bootstrap_theme>=0.7.0
 numpydoc


### PR DESCRIPTION
This PR is 
* to update the configuration file for sphinx to:
  * automatically document class members including methods, attributes, properties
  * automatically document class members without docstrings
  * avoid display class members twice 
  * provide more examples for intersphinx mapping with external packages (should include your package's dependencies)
* to make tables aligned to the left
