### PR TITLE
(docs with github page) keep file .nojekyll in docs when syncing between docs/ and docsrc/_build/html/

### DIFF
--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -23,7 +23,7 @@ github:
 	@make html
 
 sync:
-	@rsync -avh _build/html/ ../docs/ --delete
+	@rsync -avh --exclude '.nojekyll' _build/html/ ../docs/ --delete
 	@make clean
 
 clean:


### PR DESCRIPTION
 Currently, we update the contents of [docs/](https://github.com/pysal/submodule_template/tree/master/docs) with the built html files in docsrc/_build/html/ (after running `make html`). The existing files in docs/ which do not match those from docsrc/_build/html/ are deleted including  .nojekyll 

This PR is to adjust the makefile to keep .nojekyll in docs/ when syncing between docs/ and docsrc/_build/html/

also see https://github.com/pysal/libpysal/pull/207